### PR TITLE
Replace Bitly links on links page with direct social URLs

### DIFF
--- a/app/links/page.js
+++ b/app/links/page.js
@@ -13,7 +13,7 @@ const links = [
     symbol: "🔊",
   },
   {
-    url: "https://bit.ly/synwrks-youtube",
+    url: "https://www.youtube.me/synwrks",
     title: "YouTube",
     description: "Original music videos, VR & V-DJ sets recordings",
     icon: "/images/youtube.png",
@@ -43,13 +43,13 @@ const links = [
     icon: "/images/twitch.png",
   },
   {
-    url: "https://bit.ly/synwrks-facebook",
+    url: "https://www.facebook.com/synestheticworks",
     title: "Facebook",
     description: "Art & updates",
     icon: "/images/facebook.png",
   },
   {
-    url: "https://bit.ly/synwrks-twitter",
+    url: "https://x.com/synwrks",
     title: "X",
     description: "Quick updates",
     icon: "/images/twitter.png",


### PR DESCRIPTION
### Motivation
- Remove Bitly shortened URLs on the links page to point directly to official social pages for clarity and reliability.

### Description
- Updated `app/links/page.js` to replace three Bitly links with direct URLs: YouTube → `https://www.youtube.me/synwrks`, Facebook → `https://www.facebook.com/synestheticworks`, and X → `https://x.com/synwrks`.

### Testing
- Ran `npm run typecheck` and `npm run test`; both commands failed because the `typecheck` and `test` scripts are not defined in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5d4f4a4a88322a52d01025a3f40b6)