### PR TITLE
Fix mobile-stretched icons on Links page

### DIFF
--- a/src/styles/pages/links.scss
+++ b/src/styles/pages/links.scss
@@ -35,9 +35,17 @@
 
 .icon-container {
   flex: 0 0 60px;
+  width: 60px;
   height: 60px;
   margin-right: 0;
   margin-left: 20px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: contain;
+  }
 
   .gatsby-image-wrapper {
     width: 100%;
@@ -96,6 +104,7 @@
 
   .icon-container {
     flex: 0 0 40px;
+    width: 40px;
     height: 40px;
     margin-left: 15px;
     margin-right: 0;


### PR DESCRIPTION
### Motivation
- Mobile thumbnails next to links were appearing vertically stretched because the icon container didn't enforce square dimensions and images had no `object-fit` set.
- Make social icons preserve their aspect ratio on small screens while keeping layout unchanged on desktop.

### Description
- Updated `src/styles/pages/links.scss` to set explicit `width` + `height` on `.icon-container` (60×60 desktop, 40×40 mobile) so the container remains square.
- Added an `img` rule inside `.icon-container` with `width: 100%`, `height: 100%`, `display: block`, and `object-fit: contain` to preserve icon aspect ratio instead of stretching.
- Kept existing `.gatsby-image-wrapper` and `.symbol` rules intact so SVG/emoji fallbacks continue to work.
- Change is limited to the single stylesheet `src/styles/pages/links.scss`.

### Testing
- Ran `npm run typecheck` which failed because the `typecheck` script is not defined in `package.json`.
- Ran `npm run test` which failed because the `test` script is not defined in `package.json`.
- Ran `npm run build` which completed successfully and produced a working production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5d51659d08322a356f522f6e67ca7)