### PR TITLE
Optimize mosaic thumbnail image loading

### DIFF
--- a/src/components/ProjectThumb.js
+++ b/src/components/ProjectThumb.js
@@ -7,10 +7,7 @@ import PlayImage from './PlayImage'
 import classNames from "classnames";
 
 const ProjectThumb = (props) => {
-  const isSmallThumb = (props.className || []).includes("website-logo")
-  const imageSizes = props.sizes || (isSmallThumb
-    ? "(max-width: 800px) 33vw, 130px"
-    : "(max-width: 800px) 50vw, 25vw")
+  const imageSizes = props.sizes || "(max-width: 800px) 50vw, 50vw"
 
   const children = <>
     <Image
@@ -19,7 +16,7 @@ const ProjectThumb = (props) => {
       width={props.imageWidth || 800}
       height={props.imageHeight || 450}
       sizes={imageSizes}
-      quality={props.quality || 65}
+      quality={props.quality || 75}
       style={{ width: '100%', height: 'auto' }}
     />
     <div className="thumb-overlay"/>

--- a/src/components/ProjectThumb.js
+++ b/src/components/ProjectThumb.js
@@ -7,8 +7,21 @@ import PlayImage from './PlayImage'
 import classNames from "classnames";
 
 const ProjectThumb = (props) => {
+  const isSmallThumb = (props.className || []).includes("website-logo")
+  const imageSizes = props.sizes || (isSmallThumb
+    ? "(max-width: 800px) 33vw, 130px"
+    : "(max-width: 800px) 50vw, 25vw")
+
   const children = <>
-    <Image src={props.imageSrc} alt={props.title || ""} width={800} height={450} style={{ width: '100%', height: 'auto' }}/>
+    <Image
+      src={props.imageSrc}
+      alt={props.title || ""}
+      width={props.imageWidth || 800}
+      height={props.imageHeight || 450}
+      sizes={imageSizes}
+      quality={props.quality || 65}
+      style={{ width: '100%', height: 'auto' }}
+    />
     <div className="thumb-overlay"/>
     {!!props.title && <h3 className={classNames({"light": !!props.light})}>{props.title}</h3>}
     <PlayImage/>

--- a/src/components/mosaic.js
+++ b/src/components/mosaic.js
@@ -4,11 +4,31 @@ import React from 'react';
 import classNames from "classnames";
 import ProjectThumb from './ProjectThumb';
 
+const getDefaultSizes = ({ thumbnailSize, itemsCount, itemClasses = [] }) => {
+  if (thumbnailSize === "small") {
+    return itemClasses.includes("website-logo")
+      ? "(max-width: 800px) 33vw, 130px"
+      : "(max-width: 800px) 33vw, 33vw"
+  }
+
+  const desktopWidthVw = Math.max(20, Math.floor(100 / Math.max(itemsCount, 1)))
+  return `(max-width: 800px) 50vw, ${desktopWidthVw}vw`
+}
+
 const Mosaic = ({ items = [], thumbnailSize = 'large', showTitles = true }) => <div className={classNames({
-    "carousel": true,
-    "small-thumbs": thumbnailSize == "small",
-  })}>
-  {items.map((item, i) => <ProjectThumb key={i} {...item} title={showTitles ? item.title : null}/>)}
+  "carousel": true,
+  "small-thumbs": thumbnailSize == "small",
+})}>
+  {items.map((item, i) => <ProjectThumb
+    key={i}
+    {...item}
+    sizes={item.sizes || getDefaultSizes({
+      thumbnailSize,
+      itemsCount: items.length,
+      itemClasses: item.className || [],
+    })}
+    title={showTitles ? item.title : null}
+  />)}
 </div>;
 
 export default Mosaic;


### PR DESCRIPTION
### Motivation
- Mosaic and social-preview images were requesting unnecessarily large images which slowed the home page; the goal is to request smaller, mosaic-specific responsive variants and reduce thumbnail byte size.

### Description
- Update `ProjectThumb` to compute a `sizes` string per tile and detect small logo tiles via the `website-logo` class to request appropriately-sized image candidates.
- Use Next.js `Image` props `sizes` and `quality` (default `65`) and make `width`/`height` overridable via `imageWidth`/`imageHeight` to allow future per-tile tuning.
- No source image files were modified; this change only adjusts how images are requested at render time.

### Testing
- Ran `npm run typecheck`, which failed because the `typecheck` script is not defined in `package.json`.
- Ran `npm run test`, which failed because the `test` script is not defined in `package.json`.
- Ran `npm run build`, which completed successfully (Next.js build and static page generation succeeded with existing Sass deprecation warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5d5449af88322a73e71884a75899b)