### PR TITLE
Remove "The Book of Tea" link from /links page

### DIFF
--- a/app/links/page.js
+++ b/app/links/page.js
@@ -7,12 +7,6 @@ export const metadata = {
 
 const links = [
   {
-    url: "https://distrokid.com/hyperfollow/synwrks/the-book-of-tea",
-    title: "Listen to my latest release:",
-    description: '"The Book of Tea"',
-    symbol: "🔊",
-  },
-  {
     url: "https://www.youtube.me/synwrks",
     title: "YouTube",
     description: "Original music videos, VR & V-DJ sets recordings",


### PR DESCRIPTION
## Summary
- Drops the "Listen to my latest release: The Book of Tea" entry that sat at the top of the [`/links`](app/links/page.js) page (the Distrokid hyperfollow).
- Rest of the page is untouched — YouTube is now the first item in the list.

## Test plan
- [x] `npx next dev` and navigate to `/links`: list renders without the Book of Tea entry, no console errors.
- [ ] Visual sanity check on the deployed preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)